### PR TITLE
Typo in path fixed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV LFS=/mnt/lfs
 # Other LFS parameters
 ENV LC_ALL=POSIX
 ENV LFS_TGT=x86_64-lfs-linux-gnu
-ENV PATH=/tools/bin:/bin:/usr/bin:/sbin:/usr:sbin
+ENV PATH=/tools/bin:/bin:/usr/bin:/sbin:/usr/sbin
 ENV MAKEFLAGS="-j 1"
 
 # Defines how toolchain is fetched


### PR DESCRIPTION
I apologize, missed this when did build last time. Any other steps is fine, detailed report about ISO is here: https://gist.github.com/EvilFreelancer/45a44362a05601148e2be7fa05ea174c
